### PR TITLE
🚸 Add VampireCommandFramework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         run: dotnet pack --configuration Release -p:Version=$GitVersion_SemVer --output ./nuget
       
       - name: Upload a Build Artifact
-        if: ${{ !env.ACT && github.event_name == 'push' }}
+        if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v3.1.0
         with:
           path: ./nuget

--- a/Bloodstone.csproj
+++ b/Bloodstone.csproj
@@ -16,7 +16,7 @@
     <Authors>deca, molenzwiebel</Authors>
     <Company>deca</Company>
     <Description>Plugin framework and general utilities for V Rising mods.</Description>
-    <PackageIcon>logo.png</PackageIcon>
+    <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>License</PackageLicenseFile>
     <PackageTags>VRising</PackageTags>
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="logo.png" Pack="true" PackagePath="\" />
+    <None Include="icon.png" Pack="true" PackagePath="\" />
     <None Include="README.md" Pack="true" PackagePath="\" />
     <None Include="License" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>

--- a/Bloodstone.csproj
+++ b/Bloodstone.csproj
@@ -31,13 +31,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="logo.png" Pack="true" PackagePath="\" />
-    <None Include="README.md" Pack="true" PackagePath="\" />
-    <None Include="License" Pack="true" Visible="false" PackagePath="" />
-  </ItemGroup>
-
-  <ItemGroup>
-  
     <PackageReference Include="VRising.VampireCommandFramework" Version="0.7.0" />
     <PackageReference Include="VRising.Unhollowed.Client" Version="0.6.1.57247001" />
     <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.*" IncludeAssets="compile" />

--- a/Bloodstone.csproj
+++ b/Bloodstone.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.0.9999</Version> <!-- This is local version, otherwise property set by CI -->
+    <Version>0.0.9001</Version> <!-- This is local version, otherwise property set by CI -->
     <PackageId>VRising.Bloodstone</PackageId>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>deca, molenzwiebel</Authors>
     <Company>deca</Company>
     <Description>Plugin framework and general utilities for V Rising mods.</Description>
-    <PackageIcon>icon.png</PackageIcon>
+    <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>License</PackageLicenseFile>
     <PackageTags>VRising</PackageTags>
@@ -25,12 +25,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="\" />
+    <None Include="logo.png" Pack="true" PackagePath="\" />
     <None Include="README.md" Pack="true" PackagePath="\" />
     <None Include="License" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="logo.png" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="License" Pack="true" Visible="false" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+  
+    <PackageReference Include="VRising.VampireCommandFramework" Version="0.7.0" />
     <PackageReference Include="VRising.Unhollowed.Client" Version="0.6.1.57247001" />
     <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.*" IncludeAssets="compile" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" />

--- a/Bloodstone.csproj
+++ b/Bloodstone.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="VRising.VampireCommandFramework" Version="0.7.0" />
-    <PackageReference Include="VRising.Unhollowed.Client" Version="0.6.1.57247001" />
+    <PackageReference Include="VRising.Unhollowed.Client" Version="0.6.5.57575071" />
     <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.*" IncludeAssets="compile" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" />
     <PackageReference Include="Iced" Version="1.18.0" />

--- a/BloodstonePlugin.cs
+++ b/BloodstonePlugin.cs
@@ -3,6 +3,7 @@ using BepInEx.Configuration;
 using BepInEx.Logging;
 using BepInEx.Unity.IL2CPP;
 using Bloodstone.API;
+using Bloodstone.Features;
 
 namespace Bloodstone
 {
@@ -33,6 +34,7 @@ namespace Bloodstone
             // Hooks
             if (VWorld.IsServer)
             {
+                CommandFrameworkRegistration.Initialize();
                 Hooks.Chat.Initialize();
             }
 
@@ -51,7 +53,7 @@ namespace Bloodstone
             // NOTE: MUST BE LAST. This initializes plugins that depend on our state being set up.
             if (VWorld.IsClient || _enableReloadCommand.Value)
             {
-                Features.Reload.Initialize(_reloadCommand.Value, _reloadPluginsFolder.Value);
+                Features.Reload.Initialize(_reloadPluginsFolder.Value);
             }
         }
 
@@ -60,6 +62,7 @@ namespace Bloodstone
             // Hooks
             if (VWorld.IsServer)
             {
+                CommandFrameworkRegistration.Uninitialize();
                 Hooks.Chat.Uninitialize();
             }
 

--- a/CommandFramework/ChatCommandContext.cs
+++ b/CommandFramework/ChatCommandContext.cs
@@ -1,0 +1,55 @@
+﻿using Bloodstone.API;
+using Bloodstone.Hooks;
+using ProjectM;
+using ProjectM.Network;
+using System;
+using VampireCommandFramework;
+
+namespace Bloodstone.CommandFramework;
+
+/// <summary>
+/// This context is built around the in game chat event.
+/// If you want your commands to be reusable you should define them againts <see cref="ICommandContext"/>
+/// </summary>
+/// <remarks>
+/// You would use this context primarily when you need to access the character or chat event directly.
+/// </remarks>
+/// <example>
+/// public class MyCommands
+/// {
+///		[ChatCommand(".close"]
+///		public void WhosClose(CommandContext ctx)
+///		{
+///			var characterEntity =  ctx.Event.SenderCharacterEntity
+///			var (distance, name) = GetClosestTeammate(characterEntity);
+///			ctx.Reply($"{name} is {distance} away")
+///		}
+/// }
+/// </example>
+public class ChatCommandContext : ICommandContext
+{
+    public VChatEvent Event { get; }
+
+    public ChatCommandContext(VChatEvent e)
+    {
+        Event = e;
+    }
+
+    public User User => Event.User;
+
+    public IServiceProvider Services { get; }
+
+    public string Name => User.CharacterName.ToString();
+    public bool IsAdmin => User.IsAdmin;
+    public void Reply(string v)
+    {
+        ServerChatUtils.SendSystemMessageToClient(VWorld.Server.EntityManager, User, v);
+    }
+
+    // todo: expand this, just throw from here as void and build a handler that can message user/log.
+    // note: return exception lets callers throw ctx.Error() and control flow is obvious 
+    public CommandException Error(string LogMessage)
+    {
+        return new CommandException(LogMessage);
+    }
+}

--- a/CommandFramework/CommandFrameworkChatPatch.cs
+++ b/CommandFramework/CommandFrameworkChatPatch.cs
@@ -1,0 +1,59 @@
+﻿using ProjectM.Network;
+using ProjectM;
+using Unity.Entities;
+using HarmonyLib;
+using Unity.Collections;
+using System;
+using Bloodstone.Hooks;
+using Bloodstone.API;
+using VampireCommandFramework;
+
+namespace Bloodstone.CommandFramework;
+
+[HarmonyPriority(200)]
+[HarmonyPatch(typeof(ChatMessageSystem), nameof(ChatMessageSystem.OnUpdate))]
+public static class CommandFrameworkChatPatch
+{
+    public static bool Prefix(ChatMessageSystem __instance)
+    {
+        NativeArray<Entity> entities = __instance.__ChatMessageJob_entityQuery.ToEntityArray(Allocator.Temp);
+        foreach (var entity in entities)
+        {
+            var fromData = __instance.EntityManager.GetComponentData<FromCharacter>(entity);
+            var chatEventData = __instance.EntityManager.GetComponentData<ChatMessageEvent>(entity);
+
+            var messageText = chatEventData.MessageText.ToString();
+
+            VChatEvent ev = new VChatEvent(fromData.User, fromData.Character, messageText, chatEventData.MessageType);
+            var ctx = new ChatCommandContext(ev);
+
+            CommandResult result;
+            try
+            {
+                result = CommandRegistry.Handle(ctx, messageText);
+            }
+            catch (Exception e)
+            {
+                BloodstonePlugin.Logger.LogError($"Error while handling chat message {e}");
+                continue;
+            }
+
+            // Legacy .help pass through support
+            if (result == CommandResult.Success && messageText.StartsWith(".help-legacy", System.StringComparison.InvariantCulture))
+            {
+                chatEventData.MessageText = messageText.Replace("-legacy", string.Empty);
+                __instance.EntityManager.SetComponentData(entity, chatEventData);
+                return true;
+            }
+
+            else if (result != CommandResult.Unmatched)
+            {
+                VWorld.Server.EntityManager.DestroyEntity(entity);
+                return true;
+            }
+
+        }
+
+        return true;
+    }
+}

--- a/CommandFramework/CommandFrameworkRegistration.cs
+++ b/CommandFramework/CommandFrameworkRegistration.cs
@@ -1,0 +1,38 @@
+﻿using Bloodstone.API;
+using HarmonyLib;
+using VampireCommandFramework;
+using VampireCommandFramework.Basics;
+
+namespace Bloodstone.Features;
+
+internal class CommandFrameworkRegistration
+{
+    private static Harmony _harmomy;
+
+    public static void Initialize()
+    {
+        if (!VWorld.IsServer)
+        {
+            BloodstonePlugin.Logger.LogMessage("Note: Vampire Command Framework is loading on the client but only adds functionality on the server at this time, seeing this message is not a problem or bug.");
+            return;
+        }
+
+        CommandRegistry.RegisterCommandType(typeof(HelpCommands));
+        CommandRegistry.RegisterCommandType(typeof(BepInExConfigCommands));
+        CommandRegistry.RegisterCommandType(typeof(Reload));
+
+
+        _harmomy = Harmony.CreateAndPatchAll(typeof(Bloodstone.CommandFramework.CommandFrameworkChatPatch));
+    }
+
+    public static void Uninitialize()
+    {
+        if (!VWorld.IsServer)
+        {
+            return;
+        }
+
+        _harmomy.UnpatchSelf();
+
+    }
+}

--- a/FodyWeavers.xml
+++ b/FodyWeavers.xml
@@ -4,6 +4,7 @@
         <IncludeAssemblies>
             Standart.Hash.xxHash
             System.Text.Json
+            VCF.Core
         </IncludeAssemblies>
     </Costura>
 </Weavers>


### PR DESCRIPTION
This change will enable mods that previously used VampireCommandFramework to switch to using Bloodstone.

Primarily the work behind this is factoring the existing VampireCommandFramework plugin into two assemblies, one that's a BepInEx pure library: `VCF.Core` , the other that's a V Rising plugin `VampireCommandFramework`, after 0.6.0 there is no longer a plugin by that name. Details: https://github.com/decaprime/VampireCommandFramework/pull/12

This change pulls `VCF.Core` in via the same package. Although it's not ideal to shift the purpose of the existing pacakge, these changes represent a choice in the road to no longer support a stand alone plugin hosting the framework; that hosting will be done here in Bloodstone. When you look at the changes you'll see the V Rising aspect is the minority of what we call `VampireCommandFramework` that now lives in `Bloodstone.CommandFramework`

For sake of transition and scope; I've maintained mostly the same namespaces from VampireCommandFramework for now. It's future work to reposition that repository as purely about the library.