### PR TITLE
Fixed server to client network serialization

### DIFF
--- a/Network/EventDispatcher.cs
+++ b/Network/EventDispatcher.cs
@@ -23,6 +23,7 @@ internal static class EventDispatcher
 
         var em = VWorld.Server.EntityManager;
         var entity = em.CreateEntity(
+            ComponentType.ReadOnly<SendNetworkEventTag>(),
             ComponentType.ReadOnly<NetworkEventType>(),
             ComponentType.ReadOnly<SendEventToUser>(),
             CustomNetworkEvent.ComponentType
@@ -35,7 +36,7 @@ internal static class EventDispatcher
 
         em.SetComponentData<NetworkEventType>(entity, new()
         {
-            EventId = SerializationHooks.Bloodstone_NETWORK_EVENT_ID,
+            EventId = SerializationHooks.BLOODSTONE_NETWORK_EVENT_ID,
             IsAdminEvent = false,
             IsDebugEvent = false
         });
@@ -65,7 +66,7 @@ internal static class EventDispatcher
 
         em.SetComponentData<NetworkEventType>(entity, new()
         {
-            EventId = SerializationHooks.Bloodstone_NETWORK_EVENT_ID,
+            EventId = SerializationHooks.BLOODSTONE_NETWORK_EVENT_ID,
             IsAdminEvent = false,
             IsDebugEvent = false
         });

--- a/Network/SerializationHooks.cs
+++ b/Network/SerializationHooks.cs
@@ -8,6 +8,8 @@ using Unity.Entities;
 using Bloodstone.API;
 using Bloodstone.Util;
 using static NetworkEvents_Serialize;
+using HarmonyLib;
+using ProjectM;
 
 namespace Bloodstone.Network;
 
@@ -15,10 +17,13 @@ namespace Bloodstone.Network;
 internal static class SerializationHooks
 {
     // chosen by fair dice roll
-    internal const int Bloodstone_NETWORK_EVENT_ID = 0x000FD00D;
+    internal const int BLOODSTONE_NETWORK_EVENT_ID = 0x000FD00D;
 
     private static INativeDetour? _serializeDetour;
     private static INativeDetour? _deserializeDetour;
+    private static INativeDetour? _eventsReceivedDetour;
+
+    private static Harmony? _harmony;
 
     // Detour events.
     public static void Initialize()
@@ -28,6 +33,11 @@ internal static class SerializationHooks
             _serializeDetour = NativeHookUtil.Detour(typeof(NetworkEvents_Serialize), "SerializeEvent", SerializeHook, out SerializeOriginal);
             _deserializeDetour = NativeHookUtil.Detour(typeof(NetworkEvents_Serialize), "DeserializeEvent", DeserializeHook, out DeserializeOriginal);
         }
+
+        if (VWorld.IsClient)
+            _eventsReceivedDetour = NativeHookUtil.Detour(typeof(ClientBootstrapSystem), nameof(ClientBootstrapSystem.OnReliableEventsReceived), EventsReceivedHook, out EventsReceivedOriginal);
+        else if (VWorld.IsServer)
+            _harmony = Harmony.CreateAndPatchAll(typeof(SerializeAndSendServerEventsSystem_Patch));
     }
 
     // Undo detours.
@@ -35,6 +45,8 @@ internal static class SerializationHooks
     {
         _serializeDetour?.Dispose();
         _deserializeDetour?.Dispose();
+        _eventsReceivedDetour?.Dispose();
+        _harmony?.UnpatchSelf();
     }
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
@@ -45,7 +57,7 @@ internal static class SerializationHooks
     public unsafe static void SerializeHook(IntPtr entityManager, NetworkEventType networkEventType, ref NetBufferOut netBufferOut, Entity entity)
     {
         // if this is not a custom event, just call the original function
-        if (networkEventType.EventId != SerializationHooks.Bloodstone_NETWORK_EVENT_ID)
+        if (networkEventType.EventId != SerializationHooks.BLOODSTONE_NETWORK_EVENT_ID)
         {
             SerializeOriginal!(entityManager, networkEventType, ref netBufferOut, entity);
             return;
@@ -55,7 +67,7 @@ internal static class SerializationHooks
         var data = (CustomNetworkEvent)VWorld.Server.EntityManager.GetComponentObject<Il2CppSystem.Object>(entity, CustomNetworkEvent.ComponentType);
 
         // write out the event ID and the data
-        netBufferOut.Write((uint)SerializationHooks.Bloodstone_NETWORK_EVENT_ID);
+        netBufferOut.Write((uint)SerializationHooks.BLOODSTONE_NETWORK_EVENT_ID);
         data.Serialize(ref netBufferOut);
     }
 
@@ -69,7 +81,7 @@ internal static class SerializationHooks
     public unsafe static void DeserializeHook(IntPtr entityManager, IntPtr commandBuffer, ref NetBufferIn netBufferIn, DeserializeNetworkEventParams eventParams)
     {
         var eventId = netBufferIn.ReadUInt32();
-        if (eventId != SerializationHooks.Bloodstone_NETWORK_EVENT_ID)
+        if (eventId != SerializationHooks.BLOODSTONE_NETWORK_EVENT_ID)
         {
             // rewind the buffer
             netBufferIn.m_readPosition -= 32;
@@ -95,6 +107,74 @@ internal static class SerializationHooks
             {
                 BloodstonePlugin.Logger.LogError($"Error handling incoming network event {typeName}:");
                 BloodstonePlugin.Logger.LogError(ex);
+            }
+        }
+    }
+
+    // --------------------------------------------------------------------------------------
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    public unsafe delegate void EventsReceived(IntPtr _this, ref NetBufferIn netBuffer);
+
+    public static EventsReceived? EventsReceivedOriginal;
+
+    public unsafe static void EventsReceivedHook(IntPtr _this, ref NetBufferIn netBuffer)
+    {
+        var eventId = netBuffer.ReadInt32();
+        if (eventId != SerializationHooks.BLOODSTONE_NETWORK_EVENT_ID)
+        {
+            netBuffer.m_readPosition -= 32;
+            EventsReceivedOriginal!(_this, ref netBuffer);
+            return;
+        }
+
+        var typeName = netBuffer.ReadString(Allocator.Temp);
+        if (MessageRegistry._eventHandlers.ContainsKey(typeName))
+        {
+            var handler = MessageRegistry._eventHandlers[typeName];
+
+            try
+            {
+                handler.OnReceiveFromServer(netBuffer);
+            }
+            catch (Exception ex)
+            {
+                BloodstonePlugin.Logger.LogError($"Error handling incoming network event {typeName}:");
+                BloodstonePlugin.Logger.LogError(ex);
+            }
+        }
+    }
+
+    // --------------------------------------------------------------------------------------
+
+    private static class SerializeAndSendServerEventsSystem_Patch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(SerializeAndSendServerEventsSystem), nameof(SerializeAndSendServerEventsSystem.OnUpdate))]
+        private static void OnUpdatePrefix(SerializeAndSendServerEventsSystem __instance)
+        {
+            var entities = __instance._Query.ToEntityArray(Allocator.Temp);
+            var toUserTypeIndex = ComponentType.ReadOnly<SendEventToUser>().TypeIndex;
+
+            foreach (var entity in entities)
+            {
+                var eventType = __instance.EntityManager.GetComponentData<NetworkEventType>(entity);
+                if (eventType.EventId == SerializationHooks.BLOODSTONE_NETWORK_EVENT_ID)
+                {
+                    var data = __instance.EntityManager.GetComponentObject<CustomNetworkEvent>(entity);
+                    unsafe
+                    {
+                        SendEventToUser toUser = *(SendEventToUser*)__instance.EntityManager.GetComponentDataRawRO(entity, toUserTypeIndex);
+
+                        var netBuffer = new NetBufferOut(new NativeList<byte>(16384, Allocator.Temp));
+                        netBuffer.Write((byte)PacketType.Events);
+                        netBuffer.Write(eventType.EventId);
+                        data.Serialize(ref netBuffer);
+
+                        __instance._ServerBootstrapSystem.SendPacketToUser(netBuffer.Data, netBuffer.Data.Length * 8, toUser.UserIndex, true);
+                    }
+                    __instance.EntityManager.DestroyEntity(entity);
+                }
             }
         }
     }


### PR DESCRIPTION
Added the SendNetworkEventTag to the entity in EventDispatcher because it is now required for the SerializeAndSendServerEventsSystem. If the entity does not have this tag it is not seen as an event message.

Patched the SerializeAndSendServerEventsSystem OnUpdate method to manually handle sending custom event messages. This is required because the update method, or update job, is trying to find the serialization method for the event type being sent. However, it cannot find the custom serialization method and will fail.

Detoured the ClientBootstrap OnReliableEventsReceived method to handle receiving the custom event messages sent by the SerializeAndSendServerEventsSystem. This is required because there is no reference to see the original event packet structure, so we have to deserialize it manually.