### PR TITLE
📌 Pin BepInEx to 668

### DIFF
--- a/Bloodstone.csproj
+++ b/Bloodstone.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="VRising.Unhollowed.Client" Version="0.6.5.57575071" />
-    <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.*" IncludeAssets="compile" />
+    <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.668" IncludeAssets="compile" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" />
     <PackageReference Include="Iced" Version="1.18.0" />
     <PackageReference Include="Standart.Hash.xxHash" Version="3.1.0">


### PR DESCRIPTION
Updating the csproj to pin BIE version as newer builds on this spec might not work for all projects.