### PR TITLE
Add chat message classes

### DIFF
--- a/BloodstonePlugin.cs
+++ b/BloodstonePlugin.cs
@@ -3,6 +3,7 @@ using BepInEx.Configuration;
 using BepInEx.Logging;
 using BepInEx.Unity.IL2CPP;
 using Bloodstone.API;
+using Bloodstone.Network;
 
 namespace Bloodstone
 {
@@ -35,12 +36,14 @@ namespace Bloodstone
             if (VWorld.IsServer)
             {
                 Hooks.Chat.Initialize();
+                MessageUtils.RegisterClientInitialisationType();
             }
 
             if (VWorld.IsClient)
             {
                 API.KeybindManager.Load();
                 // Hooks.Keybindings.Initialize();
+                Hooks.ClientChat.Initialize();
             }
 
             Hooks.OnInitialize.Initialize();
@@ -62,12 +65,14 @@ namespace Bloodstone
             if (VWorld.IsServer)
             {
                 Hooks.Chat.Uninitialize();
+                MessageUtils.UnregisterClientInitialisationType();
             }
 
             if (VWorld.IsClient)
             {
                 API.KeybindManager.Save();
                 Hooks.Keybindings.Uninitialize();
+                Hooks.ClientChat.Uninitialize();
             }
 
             Hooks.OnInitialize.Uninitialize();

--- a/Hooks/ClientChat.cs
+++ b/Hooks/ClientChat.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Bloodstone.Network;
+using HarmonyLib;
+using ProjectM.Network;
+using ProjectM.UI;
+using Unity.Collections;
+
+namespace Bloodstone.Hooks;
+
+public static class ClientChat
+{
+    private static Harmony? _harmony;
+
+    public static void Initialize()
+    {
+        if (_harmony != null)
+            throw new Exception("Detour already initialized. You don't need to call this. The Bloodstone plugin will do it for you.");
+
+        _harmony = Harmony.CreateAndPatchAll(typeof(ClientChat), MyPluginInfo.PLUGIN_GUID);
+    }
+
+    public static void Uninitialize()
+    {
+        if (_harmony == null)
+            throw new Exception("Detour wasn't initialized. Are you trying to unload Bloodstone twice?");
+
+        _harmony.UnpatchSelf();
+    }
+    
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(ClientChatSystem), nameof(ClientChatSystem.OnUpdate))]
+    private static void OnUpdatePrefix(ClientChatSystem __instance)
+    {
+        var entities = __instance.__query_172511197_1.ToEntityArray(Allocator.Temp);
+        foreach (var entity in entities)
+        {
+            var ev = __instance.EntityManager.GetComponentData<ChatMessageServerEvent>(entity);
+            if (ev.MessageType == ServerChatMessageType.System && MessageUtils.DeserialiseMessage(ev.MessageText.ToString()))
+            {
+                // Remove this as it is an internal message that the user is unlikely wanting to see in their chat
+                __instance.EntityManager.DestroyEntity(entity);
+            }
+        }
+    }
+}

--- a/Network/MessageChatRegistry.cs
+++ b/Network/MessageChatRegistry.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Bloodstone.Network;
+
+// Tracks internal registered message types and their event handlers.
+internal class MessageChatRegistry
+{
+    internal static Dictionary<string, RegisteredChatEventHandler> _eventHandlers = new();
+
+    internal static void Register<T>(RegisteredChatEventHandler handler)
+    {
+        var key = MessageRegistry.DeriveKey(typeof(T));
+
+        if (_eventHandlers.ContainsKey(key))
+            throw new Exception($"Network event {key} is already registered");
+
+        _eventHandlers.Add(key, handler);
+    }
+
+    internal static void Unregister<T>()
+    {
+        var key = MessageRegistry.DeriveKey(typeof(T));
+
+        // don't throw if it doesn't exist
+        _eventHandlers.Remove(key);
+    }
+}
+
+internal class RegisteredChatEventHandler
+{
+#nullable disable
+    internal Action<BinaryReader> OnReceiveFromServer { get; init; }
+#nullable enable
+}

--- a/Network/MessageUtils.cs
+++ b/Network/MessageUtils.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Bloodstone.API;
+using ProjectM;
+using ProjectM.Network;
+
+namespace Bloodstone.Network;
+
+public delegate void ClientConnectionMessageHandler(User fromCharacter);
+
+public static class MessageUtils
+{
+    public static event ClientConnectionMessageHandler? OnClientConnectionEvent;
+    
+    internal static readonly int ClientNonce = Random.Shared.Next(); 
+    private static Dictionary<ulong, int> supportedUsers = new();
+
+    internal struct ClientRegister
+    {
+        public int clientNonce;
+    }
+    
+    internal static void RegisterClientInitialisationType()
+    {
+        if (VWorld.IsClient) throw new System.Exception("RegisterClientInitialisationType can only be called on the server.");
+        
+        VNetworkRegistry.RegisterServerboundStruct((FromCharacter from, ClientRegister register) =>
+        {
+            var user = VWorld.Server.EntityManager.GetComponentData<User>(from.User);
+            supportedUsers[user.PlatformId] = register.clientNonce;
+            
+            OnClientConnectionEvent?.Invoke(user);
+        });
+    }
+    
+    internal static void UnregisterClientInitialisationType()
+    {
+        if (VWorld.IsClient) throw new System.Exception("UnregisterClientInitialisationType can only be called on the server.");
+        
+        VNetworkRegistry.UnregisterStruct<ClientRegister>();
+    }
+
+    public static void RegisterType<T>(Action<T> onServerMessageEvent) where T : VNetworkChatMessage, new()
+    {
+        MessageChatRegistry.Register<T>(new()
+        {
+            OnReceiveFromServer = br =>
+            {
+                var msg = new T();
+                msg.Deserialize(br);
+                onServerMessageEvent.Invoke(msg);
+            }
+        });
+    }
+    
+    public static void InitialiseClient()
+    {
+        if (VWorld.IsServer) throw new System.Exception("InitialiseClient can only be called on the client.");
+        VNetwork.SendToServerStruct(new ClientRegister() { clientNonce = ClientNonce });
+    }
+    
+    public static void SendToClient<T>(User toCharacter, T msg) where T : VNetworkChatMessage
+    {
+        BloodstonePlugin.Logger.LogDebug("[SERVER] [SEND] VNetworkChatMessage");
+
+        // Note: Bloodstone currently doesn't support sending custom server messages to the client :(
+        // VNetwork.SendToClient(toCharacter, msg);
+            
+        // ... instead we are going to send the user a chat message, as long as we have them in our initialised list.
+        if (supportedUsers.TryGetValue(toCharacter.PlatformId, out var userNonce))
+        {
+            ServerChatUtils.SendSystemMessageToClient(VWorld.Server.EntityManager, toCharacter, $"{SerialiseMessage(msg, userNonce)}");
+        }
+        else
+        {
+            BloodstonePlugin.Logger.LogDebug("user nonce not present in supportedUsers");
+        }
+    }
+    
+    private static void WriteHeader(BinaryWriter writer, string type, int clientNonce)
+    {
+        writer.Write(type);
+        writer.Write(clientNonce);
+    }
+
+    private static bool ReadHeader(BinaryReader reader, out int userNonce, out string type)
+    {
+        type = "";
+        userNonce = 0;
+        
+        try
+        {
+            type = reader.ReadString();
+            userNonce = reader.ReadInt32();
+            
+            return true;
+        }
+        catch (Exception e)
+        {
+            BloodstonePlugin.Logger.LogDebug($"Failed to read chat message header: {e.Message}");
+
+            return false;
+        }
+    }
+
+    private static string SerialiseMessage<T>(T msg, int clientNonce) where T : VNetworkChatMessage
+    {
+        using var stream = new MemoryStream();
+        using var bw = new BinaryWriter(stream);
+        
+        WriteHeader(bw, MessageRegistry.DeriveKey(msg.GetType()), clientNonce);
+        
+        msg.Serialize(bw);
+        return Convert.ToBase64String(stream.ToArray());
+    }
+
+    internal static bool DeserialiseMessage(string message)
+    {
+        var type = "";
+        try
+        {
+            var bytes = Convert.FromBase64String(message);
+
+            using var stream = new MemoryStream(bytes);
+            using var br = new BinaryReader(stream);
+
+            // If we can't read the header, it is likely not a VNetworkChatMessage
+            if (!ReadHeader(br, out var clientNonce, out type)) return false;
+
+            if (MessageChatRegistry._eventHandlers.TryGetValue(type, out var handler))
+            {
+                handler.OnReceiveFromServer(br);
+            }
+
+            return true;
+        }
+        catch (FormatException)
+        {
+            BloodstonePlugin.Logger.LogDebug("Invalid base64");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            BloodstonePlugin.Logger.LogError($"Error handling incoming network event {type}:");
+            BloodstonePlugin.Logger.LogError(ex);
+            
+            return false;
+        }
+    }
+}

--- a/Network/VNetworkChatMessage.cs
+++ b/Network/VNetworkChatMessage.cs
@@ -1,0 +1,10 @@
+﻿using System.IO;
+
+namespace Bloodstone.Network;
+
+public interface VNetworkChatMessage
+{
+    public void Serialize(BinaryWriter writer);
+
+    public void Deserialize(BinaryReader reader);
+}


### PR DESCRIPTION
Adding in chat message alternate form of communication from server -> client.

First draft of adding it to Bloodstone (this form is currently untested, but the theory works). Am after any design changes or updates that I should make.

Tests would be useful to add.

Intended use:

SharedLibrary:

```
public struct DataPacket : VNetworkChatMessage
{
  string Data;
}
```

Server:

```
MessageUtils.OnClientConnectionEvent += (User user) => {
   // Client has connected! woo! now I can send them messages!
}
```

Client:

```
MessageUtils.RegisterType<DataPacket>((DataPacket message) => {
  // I have received this message. Need to cast it into appropriate type
});

// After client has sufficiently loaded to be able to receive messages
MessageUtils.InitialiseClient();
```